### PR TITLE
Fix LightGBM comment typo

### DIFF
--- a/nonlinear_model_training.py
+++ b/nonlinear_model_training.py
@@ -49,7 +49,7 @@ for seed in seeds:
 
     # === LightGBM ===
     # lgb = LGBMRegressor(n_estimators=100, random_state=42)
-    # Best performaing LGBM parameters from tuning
+    # Best performing LGBM parameters from tuning
     lgb = LGBMRegressor(
         subsample=0.8,
         n_estimators=500,


### PR DESCRIPTION
## Summary
- correct a typo in the LightGBM section of `nonlinear_model_training.py`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886d8713284833296bb95a6df527e6a