### PR TITLE
Add argparse file path options

### DIFF
--- a/ctdata_prep.py
+++ b/ctdata_prep.py
@@ -1,6 +1,13 @@
+import argparse
 import pandas as pd
 import matplotlib.pyplot as plt
 import numpy as np
+
+parser = argparse.ArgumentParser(description="Clean and merge CT data")
+parser.add_argument("--sessions", default="Data/assetmeters 07-25-2025.csv", help="Sessions CSV")
+parser.add_argument("--machines", default="Data/TTgames00 07-25-2025.csv", help="Machines CSV")
+parser.add_argument("--output", default="Data/ctdata_amtt_merge.csv", help="Output merged CSV")
+args = parser.parse_args()
 
 
 # Clean up column names --------------------------------
@@ -15,7 +22,7 @@ def clean_cols(df):
 
 # Clean up sessions DataFrame ------------------------
 def create_sessions():
-    sessions_path = "Data/assetmeters 07-25-2025.csv"
+    sessions_path = args.sessions
 
     sessions = pd.read_csv(sessions_path)
 
@@ -47,7 +54,7 @@ def create_sessions():
 
 # Clean up machines DataFrame ------------------------
 def create_machines():
-    machines_path = "Data/TTgames00 07-25-2025.csv"
+    machines_path = args.machines
 
     machines = pd.read_csv(machines_path)
 
@@ -91,4 +98,4 @@ machines = create_machines()
 
 merged = create_merged(sessions, machines)
 
-merged.to_csv("Data/ctdata_amtt_merge.csv", index=False)
+merged.to_csv(args.output, index=False)

--- a/elastic_net_training.py
+++ b/elastic_net_training.py
@@ -1,3 +1,4 @@
+import argparse
 import pandas as pd
 from sklearn.linear_model import ElasticNetCV
 from sklearn.model_selection import train_test_split
@@ -7,8 +8,12 @@ import numpy as np
 from sklearn.linear_model import RidgeCV
 from sklearn.ensemble import RandomForestRegressor
 
+parser = argparse.ArgumentParser(description="Elastic net training script")
+parser.add_argument("--features", default="Data/features.csv", help="Feature CSV")
+args = parser.parse_args()
+
 # === STEP 1: Load your features ===
-df = pd.read_csv("Data/features.csv")
+df = pd.read_csv(args.features)
 
 # === STEP 2: Define target and features ===
 # You are predicting coinin

--- a/feat_create.py
+++ b/feat_create.py
@@ -1,9 +1,13 @@
+import argparse
 import pandas as pd
 import datetime
 
-merged_path = "Data/merged_with_clusters.csv"
+parser = argparse.ArgumentParser(description="Generate machine learning features")
+parser.add_argument("--input", default="Data/merged_with_clusters.csv", help="Merged input CSV")
+parser.add_argument("--output", default="Data/features.csv", help="Output features CSV")
+args = parser.parse_args()
 
-merged = pd.read_csv(merged_path)
+merged = pd.read_csv(args.input)
 
 
 # DATE BASED FEATURES
@@ -154,4 +158,4 @@ merged = merged.drop(columns=["date", "denom", "gamesplayed", "asset", "theme", 
 print(merged["coinin"].describe())
 
 # Save the updated DataFrame back to a CSV file
-merged.to_csv("Data/features.csv", index=False)
+merged.to_csv(args.output, index=False)

--- a/feat_month_extend.py
+++ b/feat_month_extend.py
@@ -1,9 +1,15 @@
+import argparse
 import pandas as pd
 import numpy as np
 from datetime import datetime, timedelta
 
-# === STEP 1: Load full dataset ===
-df = pd.read_csv("Data/features.csv")
+# === STEP 1: Parse args and load full dataset ===
+parser = argparse.ArgumentParser(description="Extend features for next month")
+parser.add_argument("--features", default="Data/features.csv", help="Input features CSV")
+parser.add_argument("--output", default="Data/future_month_layout.csv", help="Output future layout CSV")
+args = parser.parse_args()
+
+df = pd.read_csv(args.features)
 
 # === STEP 2: Find most recent date layout ===
 # Assumes that the most recent day is the most frequent full day across machines
@@ -64,5 +70,5 @@ for day in future_dates:
 future_df = pd.DataFrame(extended_rows)
 
 # === STEP 6: Save output ===
-future_df.to_csv("Data/future_month_layout.csv", index=False)
-print("Saved future layout to 'Data/future_month_layout.csv'")
+future_df.to_csv(args.output, index=False)
+print(f"Saved future layout to '{args.output}'")

--- a/nonlinear_model_training.py
+++ b/nonlinear_model_training.py
@@ -1,3 +1,4 @@
+import argparse
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
@@ -7,8 +8,12 @@ from sklearn.ensemble import RandomForestRegressor
 from lightgbm import LGBMRegressor
 from xgboost import XGBRegressor
 
+parser = argparse.ArgumentParser(description="Train multiple nonlinear models")
+parser.add_argument("--features", default="Data/features.csv", help="Input feature CSV")
+args = parser.parse_args()
+
 # === STEP 1: Load your features ===
-df = pd.read_csv("Data/features.csv")
+df = pd.read_csv(args.features)
 
 # === STEP 2: Define target and features ===
 y = df["coinin"]

--- a/nonlinear_model_tuning.py
+++ b/nonlinear_model_tuning.py
@@ -102,6 +102,7 @@
 # print(f"[XGBoost] R²: {r2_score(y_test, y_pred_xgb):.4f}")
 # print(f"[XGBoost] Training Time: {(end - start)/60:.2f} minutes")
 
+import argparse
 import pandas as pd
 import numpy as np
 import time
@@ -112,8 +113,12 @@ from sklearn.ensemble import RandomForestRegressor
 import lightgbm as lgb
 import xgboost as xgb
 
+parser = argparse.ArgumentParser(description="Tune nonlinear models")
+parser.add_argument("--features", default="Data/features.csv", help="Feature CSV")
+args = parser.parse_args()
+
 # === STEP 1: Load your features ===
-df = pd.read_csv("Data/features.csv")
+df = pd.read_csv(args.features)
 
 # === STEP 2: Define target and features ===
 y = df["coinin"]

--- a/pre_ct/bigdata_date_merge.py
+++ b/pre_ct/bigdata_date_merge.py
@@ -1,4 +1,9 @@
+import argparse
 from bigdata_prep import create_sessions, create_machines, create_merged
+
+parser = argparse.ArgumentParser(description="Merge bigdata by date and machine")
+parser.add_argument("--output", default="Data/Merged_By_Date_MachineID_Active.csv", help="Output merged CSV")
+args = parser.parse_args()
 
 sessions = create_sessions()
 machines = create_machines()
@@ -29,7 +34,6 @@ aggregated["numsessions"] = merged.groupby(["date", "machineid"]).size().values
 aggregated["avgbet"] = aggregated["coinin"] / aggregated["numgames"]
 
 # Save the new DataFrame to a CSV file
-output_path = "Data/Merged_By_Date_MachineID_Active.csv"
-aggregated.to_csv(output_path, index=False)
+aggregated.to_csv(args.output, index=False)
 
-print(f"Aggregated data saved to {output_path}")
+print(f"Aggregated data saved to {args.output}")

--- a/pre_ct/bigdata_prep.py
+++ b/pre_ct/bigdata_prep.py
@@ -1,6 +1,13 @@
+import argparse
 import pandas as pd
 import matplotlib.pyplot as plt
 import numpy as np
+
+parser = argparse.ArgumentParser(description="Prepare bigdata sessions and machines")
+parser.add_argument("--sessions", default="Data/BigData7_24_25.csv", help="Sessions CSV")
+parser.add_argument("--machines", default="Data/SlotsOnFloor.csv", help="Machines CSV")
+parser.add_argument("--output", default="Data/bigdata_merge_active.csv", help="Merged output CSV")
+args = parser.parse_args()
 
 
 # Clean up column names --------------------------------
@@ -15,7 +22,7 @@ def clean_cols(df):
 
 # Clean up sessions DataFrame ------------------------
 def create_sessions():
-    sessions_path = "Data/BigData7_24_25.csv"
+    sessions_path = args.sessions
 
     sessions = pd.read_csv(sessions_path)
 
@@ -54,7 +61,7 @@ def create_sessions():
 
 # Clean up machines DataFrame ------------------------
 def create_machines():
-    machines_path = "Data/SlotsOnFloor.csv"
+    machines_path = args.machines
 
     machines = pd.read_csv(machines_path)
 
@@ -113,4 +120,4 @@ machines = create_machines()
 merged = create_merged(sessions, machines)
 
 
-merged.to_csv("Data/bigdata_merge_active.csv", index=False)
+merged.to_csv(args.output, index=False)

--- a/predicted_coinin.py
+++ b/predicted_coinin.py
@@ -1,10 +1,16 @@
+import argparse
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.ensemble import RandomForestRegressor
 
-# === STEP 1: Load training data ===
-df_train = pd.read_csv("Data/features.csv")
+# === STEP 1: Parse arguments and load training data ===
+parser = argparse.ArgumentParser(description="Predict coin-in for a future month")
+parser.add_argument("--features", default="Data/features.csv", help="Path to training feature CSV")
+parser.add_argument("--future-layout", default="Data/future_month_layout.csv", help="Path to future layout CSV")
+args = parser.parse_args()
+
+df_train = pd.read_csv(args.features)
 y_train = df_train["coinin"]
 X_train = df_train.drop(columns=["coinin"])
 
@@ -14,7 +20,7 @@ print("Training Random Forest Regressor on all data...")
 rf.fit(X_train, y_train)
 
 # === STEP 3: Load future month layout ===
-df_future = pd.read_csv("Data/future_month_layout.csv")
+df_future = pd.read_csv(args.future_layout)
 # Some future layouts may not already contain a ``coinin`` column.  In that
 # case we simply use the DataFrame as-is when generating features.  Attempting
 # to drop a missing column would raise a ``KeyError``.

--- a/rf_training.py
+++ b/rf_training.py
@@ -1,3 +1,4 @@
+import argparse
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
@@ -5,8 +6,12 @@ from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import mean_squared_error, r2_score, mean_absolute_error
 
+parser = argparse.ArgumentParser(description="Random forest training script")
+parser.add_argument("--features", default="Data/features.csv", help="Input feature CSV")
+args = parser.parse_args()
+
 # === STEP 1: Load features ===
-df = pd.read_csv("Data/features.csv")
+df = pd.read_csv(args.features)
 y = df["coinin"]
 X = df.drop(columns=["coinin"])
 

--- a/shap_analysis.py
+++ b/shap_analysis.py
@@ -1,14 +1,19 @@
+import argparse
 import pandas as pd
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import train_test_split
 import shap
 import matplotlib.pyplot as plt
 
+parser = argparse.ArgumentParser(description="SHAP analysis for RandomForest")
+parser.add_argument("--features", default="Data/features.csv", help="Features CSV")
+args = parser.parse_args()
+
 # === STEP 1: Load training features ===
 # Same loading approach as rf_training.py lines 8-11
 # which read the engineered feature set written by feat_create.py
 # at lines 146-157.
-df = pd.read_csv("Data/features.csv")
+df = pd.read_csv(args.features)
 y = df["coinin"]
 X = df.drop(columns=["coinin"])
 

--- a/spatial_clustering.py
+++ b/spatial_clustering.py
@@ -1,9 +1,15 @@
+import argparse
 from ctdata_prep import create_sessions, create_machines, create_merged
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from sklearn.cluster import KMeans
 from sklearn.preprocessing import StandardScaler
+
+parser = argparse.ArgumentParser(description="Cluster slot machine coordinates")
+parser.add_argument("--coord-output", default="Data/clustered_coordinates.csv", help="Output CSV for coordinates with clusters")
+parser.add_argument("--merged-output", default="Data/merged_with_clusters.csv", help="Output CSV for merged data with clusters")
+args = parser.parse_args()
 
 # === STEP 1: Load Coordinates Data ===
 sessions = create_sessions()
@@ -82,6 +88,6 @@ coord_merged = coord_merged[['x', 'y', 'cluster_id']]
 merged = merged.merge(coord_merged[['x', 'y', 'cluster_id']], on=['x', 'y'], how='left')
 
 # === Save both coord_merged and merged DataFrames to CSV ===
-coord_merged.to_csv("Data/clustered_coordinates.csv", index=False)
-merged.to_csv("Data/merged_with_clusters.csv", index=False)
+coord_merged.to_csv(args.coord_output, index=False)
+merged.to_csv(args.merged_output, index=False)
 

--- a/tier_one/data_prep.py
+++ b/tier_one/data_prep.py
@@ -1,6 +1,12 @@
+import argparse
 import pandas as pd
 import matplotlib.pyplot as plt
 import numpy as np
+
+parser = argparse.ArgumentParser(description="Prepare Player One data")
+parser.add_argument("--sessions", default="Data/PlayerOne.csv", help="Player sessions CSV")
+parser.add_argument("--machines", default="Data/SlotsOnFloor.csv", help="Machines CSV")
+args = parser.parse_args()
 
 
 # Clean up column names --------------------------------
@@ -15,7 +21,7 @@ def clean_cols(df):
 
 # Clean up sessions DataFrame ------------------------
 def create_sessions():
-    sessions_path = "Data/PlayerOne.csv"
+    sessions_path = args.sessions
 
     sessions = pd.read_csv(sessions_path)
 
@@ -50,7 +56,7 @@ def create_sessions():
 
 # Clean up machines DataFrame ------------------------
 def create_machines():
-    machines_path = "Data/SlotsOnFloor.csv"
+    machines_path = args.machines
 
     machines = pd.read_csv(machines_path)
 

--- a/tier_one/merge_playerone.py
+++ b/tier_one/merge_playerone.py
@@ -6,15 +6,23 @@ Usage:
     python merge_playerone.py
 """
 
+import argparse
 from pathlib import Path
 import re
 import pandas as pd
 
+parser = argparse.ArgumentParser(description="Merge PlayerOne Excel files")
+parser.add_argument("--data-dir", default="Data", help="Directory containing PlayerOne Excel files")
+parser.add_argument("--output", default="Data/PlayerOne.csv", help="Output CSV file")
+parser.add_argument("--glob", default="PlayerOne*.xlsx", help="Glob pattern for Excel files")
+parser.add_argument("--add-source-col", action="store_true", help="Add source file column", default=True)
+args = parser.parse_args()
+
 # ---------- configuration ----------
-DATA_DIR = Path("Data")          # folder where the Excel files live
-GLOB_PATTERN = "PlayerOne*.xlsx" # pattern to match
-OUTPUT_FILE = DATA_DIR / "PlayerOne.csv"
-ADD_SOURCE_COL = True            # set False if you don’t want the source_file column
+DATA_DIR = Path(args.data_dir)
+GLOB_PATTERN = args.glob
+OUTPUT_FILE = Path(args.output)
+ADD_SOURCE_COL = args.add_source_col
 # -----------------------------------
 
 def numeric_key(path_obj: Path) -> int:


### PR DESCRIPTION
## Summary
- add argparse argument parsing to scripts so input/output paths are configurable
- retain Data/ defaults for backward compatibility

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6886ee45c7548332a2dcb9c76ab8bff8